### PR TITLE
Adapt for mastodon v4.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM tootsuite/mastodon:v4.1.4
+FROM tootsuite/mastodon:v4.2.1
+# version suffix was removed in version 4.2.0, use ENV to add build meta instead
+ENV MASTODON_VERSION_METADATA wxw
 
 COPY --chown=991:991 ./icons /opt/mastodon/app/javascript/icons
 COPY --chown=991:991 ./images /opt/mastodon/app/javascript/images
 
 RUN echo "修改字数上限" \
   && sed -i "s|MAX_CHARS = 500|MAX_CHARS = 20000|" /opt/mastodon/app/validators/status_length_validator.rb \
-  && sed -i "s|length(fulltext) > 500|length(fulltext) > 20000|" /opt/mastodon/app/javascript/mastodon/features/compose/components/compose_form.js \
-  && sed -i "s|CharacterCounter max={500}|CharacterCounter max={20000}|" /opt/mastodon/app/javascript/mastodon/features/compose/components/compose_form.js \
+  && sed -i "s|length(fulltext) > 500|length(fulltext) > 20000|" /opt/mastodon/app/javascript/mastodon/features/compose/components/compose_form.jsx \
+  && sed -i "s|CharacterCounter max={500}|CharacterCounter max={20000}|" /opt/mastodon/app/javascript/mastodon/features/compose/components/compose_form.jsx \
   && echo "修改媒体上限" \
-  && sed -i "s|MAX_IMAGE_PIXELS = 2073600|MAX_IMAGE_PIXELS = 9999999|" /opt/mastodon/app/javascript/mastodon/utils/resize_image.js \
-  && sed -i "s|pixels: 2_073_600|pixels: 9_999_999|" /opt/mastodon/app/models/media_attachment.rb \
-  && sed -i "s|IMAGE_LIMIT = 10|IMAGE_LIMIT = 80|" /opt/mastodon/app/models/media_attachment.rb \
-  && sed -i "s|VIDEO_LIMIT = 40|VIDEO_LIMIT = 100|" /opt/mastodon/app/models/media_attachment.rb \
+  && sed -i "s|pixels: 8_294_400|pixels: 9_999_999|" /opt/mastodon/app/models/media_attachment.rb \
+  && sed -i "s|IMAGE_LIMIT = 16|IMAGE_LIMIT = 80|" /opt/mastodon/app/models/media_attachment.rb \
+  && sed -i "s|VIDEO_LIMIT = 99|VIDEO_LIMIT = 100|" /opt/mastodon/app/models/media_attachment.rb \
   && echo "修改投票上限" \
-  && sed -i "s|options.size >= 4|options.size >= 16|" /opt/mastodon/app/javascript/mastodon/features/compose/components/poll_form.js \
+  && sed -i "s|options.size >= 4|options.size >= 16|" /opt/mastodon/app/javascript/mastodon/features/compose/components/poll_form.jsx \
   && sed -i "s|MAX_OPTIONS      = 4|MAX_OPTIONS      = 16|" /opt/mastodon/app/validators/poll_validator.rb \
   && echo "加入 No-More-Sidebar-in-Mastodon-4.0 主题" \
   && mkdir /opt/mastodon/app/javascript/styles/mastodon-no-more-sidebar \
@@ -121,7 +122,6 @@ RUN echo "修改字数上限" \
   && sed -i "s|analysis: {|analysis: {\n    char_filter: {\n      tsconvert: {\n        type: 'stconvert',\n        keep_both: false,\n        delimiter: '#',\n        convert_type: 't2s',\n      },\n    },|" /opt/mastodon/app/chewy/tags_index.rb \
   && sed -i "s|keyword',|ik_max_word',\n        char_filter: %w(tsconvert),|" /opt/mastodon/app/chewy/tags_index.rb \
   && echo "修改版本项目地址" \
-  && sed -i "/def suffix/{n;s|''|'~wxw'|}" /opt/mastodon/lib/mastodon/version.rb \
   && sed -i "s|mastodon/mastodon|wxwmoe/mastodon|" /opt/mastodon/lib/mastodon/version.rb \
   && echo "重新编译资源文件" \
   && OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile \


### PR DESCRIPTION
Hello~
I learned a lot from your docker file to build my instance. And I tried to make some changes to it to adapt mastodon v4.2.1 if you need.

Some changes:
  - Some file changes its name (`.js` -> `.jsx`)
  - `suffix` field in `version.rb` was removed. use `MASTODON_VERSION_METADATA` env to fill the `build_metadata` field instead. The version may shows `v4.2.1+wxw` for now.
  - Attachment resizing has been removed from client side so `utils/resize_image.js` was removed.

Mastodon v4.2.0 has updated media size limits to:
 - pixels 2_073_600 (1920x1080px) -> 8_294_400 (3840x2160px)
 - IMAGE_LIMIT 10 -> 16 MB
 - VIDEO_LIMIT 40 -> 99 MB

ref: https://github.com/mastodon/mastodon/commit/9bda93374093c738f1007922b2e8df58043c718f (#23726)

For the theme and search optimize, it could pass the docker build without any change but not yet tested.